### PR TITLE
rel="canonical"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,10 @@ logo: logo.png
 markdown: kramdown
 pygments: true
 
+# always points to production site
+canonical: https://www.notalone.gov
+
+# any path prefix to apply, run with --baseurl="" in development
 baseurl: /campus
 
 kramdown:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=0.75">
     <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.name }}</title>
     <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-    
+
     <link href="{{ site.baseurl }}/static/css/style.css?c={{ site.cachebuster }}" rel="stylesheet">
+
+    <link rel="canonical" href="{{ site.canonical }}{{page.url }}" />
+
     <!--[if lte IE 7]>
       <style>body { display: none !important; }</style>
       <script type="text/javascript">
@@ -23,13 +26,13 @@
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    
+
     <script src="{{ site.baseurl }}/static/js/min/jquery.min.js"></script>
   <!--  <script src="{{ site.baseurl }}/static/js/min/iecors.min.js"></script> -->
   <!--[if lte IE 9]>
   <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.0/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
-    
+
   </head>
   <body>
     <div class="usa">An official website of the United States Government <img class="flag" src="{{ site.baseurl }}/static/img/us_flag_small.png" class="USA Flag" /></div>
@@ -127,7 +130,7 @@
             <a class="credit-title img oneistwomany" style="background-image:url('{{ site.baseurl }}/static/img/1is2many.png');" href="http://whitehouse.gov/1is2many">1is2 Many</a>
              In Partnership with <a href="http://whitehouse.gov/1is2many">www.whitehouse.gov/1is2many</a>
           </div>
-          
+
           <div class="credit">
             <a class="credit-title img eighteenf" style="background-image:url('{{ site.baseurl }}/static/img/18f.png');" href="https://18f.gsa.gov">18F</a>
             Made by <a href="https://18f.gsa.gov">18F</a> and <a href="http://whitehouse.gov/innovationfellows">Presidential Innovation Fellows</a>

--- a/contact/index.md
+++ b/contact/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Contact
 description: Information about how to access hotlines, give feedback, and contact the White House Task Force to Protect Students from Sexual Assault.
+permalink: /contact/
 ---
 
 
@@ -9,7 +10,7 @@ description: Information about how to access hotlines, give feedback, and contac
 
 #### The Office of the Vice President
 
-You may contact the Office of the Vice President via [email](malito:notalone@ovp.eop.gov). 
+You may contact the Office of the Vice President via [email](malito:notalone@ovp.eop.gov).
 
 
 #### U.S. Department of Education, Office for Civil Rights (OCR)
@@ -26,12 +27,12 @@ You may contact HHS via [email](malito:womenshealth@hhs.gov) or call 800-994-966
 
 **Civil Rights Division (CRT)**
 
-You may contact CRT via [email](mailto:education@usdoj.gov). 
+You may contact CRT via [email](mailto:education@usdoj.gov).
 You can also call CRT at 1-877-292-3804.
 
 **Office on Violence Against Women (OVW)**
 
-You may contact OVW via [email](malito:OVWinfo@usdoj.gov) 
+You may contact OVW via [email](malito:OVWinfo@usdoj.gov)
 or visit their [website](http://www.ovw.usdoj.gov/).
 
 
@@ -43,6 +44,6 @@ or visit their [website](http://www.ovw.usdoj.gov/).
 
 ## Feedback
 
-The White House Task Force to Protect Students from Sexual Assault strives to provide comprehensive and inclusive resources on how to prevent and respond to sexual assault on college and university campuses and in our schools. We appreciate your partnership in efforts to eliminate sexual violence. 
+The White House Task Force to Protect Students from Sexual Assault strives to provide comprehensive and inclusive resources on how to prevent and respond to sexual assault on college and university campuses and in our schools. We appreciate your partnership in efforts to eliminate sexual violence.
 
-Please contact [notalone@ovp.eop.gov](mailto:notalone@ovp.eop.gov) to send us your comments or report any problems you experienced finding information on our website. 
+Please contact [notalone@ovp.eop.gov](mailto:notalone@ovp.eop.gov) to send us your comments or report any problems you experienced finding information on our website.

--- a/data/index.md
+++ b/data/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Data
 description: Access sexual assault data on Data.gov and view school-by-school enforcement.
+permalink: /data/
 ---
 
 ## School-by-School Enforcement Map
@@ -20,11 +21,11 @@ This map includes information about resolved school-level enforcement activities
 <div class="resource-cite">Map Data Courtesy <a href="https://github.com/shannonturner/education-compliance-reports" target="_blank">Shannon Turner</a>
 </div>
 
-The U.S. Department of Education, Office for Civil Rights (OCR) is posting nearly all recent resolution letters and agreements with schools on its [website](http://www2.ed.gov/about/offices/list/ocr/docs/investigations/search-ocr.html).  OCR will also make public the schools that are under OCR investigation, including those that involve Title IX sexual violence allegations.  To ensure that the most up-to-date information is provided, interested parties should contact [OCR headquarters](malito:ocr@ed.gov) or the [closest regional office](https://wdcrobcolp01.ed.gov/CFAPPS/OCR/contactus.cfm). 
+The U.S. Department of Education, Office for Civil Rights (OCR) is posting nearly all recent resolution letters and agreements with schools on its [website](http://www2.ed.gov/about/offices/list/ocr/docs/investigations/search-ocr.html).  OCR will also make public the schools that are under OCR investigation, including those that involve Title IX sexual violence allegations.  To ensure that the most up-to-date information is provided, interested parties should contact [OCR headquarters](malito:ocr@ed.gov) or the [closest regional office](https://wdcrobcolp01.ed.gov/CFAPPS/OCR/contactus.cfm).
 
 ## Data.gov
 
-Data.gov contains thousands of agency data sets, tools, and research to conduct research, develop web and mobile applications, design data visualizations, and more. Currently listed are over 100 datasets that include non-sensitive information related to higher education and sexual assault reporting, research, legal guidance, and enforcement resolutions, among other topics. 
+Data.gov contains thousands of agency data sets, tools, and research to conduct research, develop web and mobile applications, design data visualizations, and more. Currently listed are over 100 datasets that include non-sensitive information related to higher education and sexual assault reporting, research, legal guidance, and enforcement resolutions, among other topics.
 
 <div class="section-context-links">
 * [View data sets related to sexual assault on Data.gov](http://catalog.data.gov/dataset?q=sexual+assault&sort=score+desc%2C+name+asc)

--- a/index.md
+++ b/index.md
@@ -1,8 +1,10 @@
 ---
 layout: home
 subtitle: '"Perhaps most important, we need to keep saying to anyone out there who has ever been assaulted:  you are not alone. <br>We have your back.  I’ve got your back."<em class="citation">President Barack Obama, January 22, 2014</em>'
-description: Sexual assault resources and information for students, schools, and advocates. 
+description: Sexual assault resources and information for students, schools, and advocates.
+permalink: /
 ---
+
 <div class="top-message">
 Information for students, schools, and anyone interested in finding resources on how to respond to and prevent sexual assault on college and university campuses and in our schools. Click explore to find a crisis service, learn more about your rights and how to file a complaint, and view a map of resolved school-level enforcement activities.
 
@@ -24,10 +26,10 @@ Information for students, schools, and anyone interested in finding resources on
 </div>
 
 <div class="top-message">
-  
-NotAlone was launched in connection with the White House Task Force to Protect Students from Sexual Assault.  The Task Force was established on January 22, 2014 – and since then, thousands of people have shared their stories and ideas about how best to eliminate sexual assault on our campuses and schools.  
 
-Here’s our [report]({{ site.baseurl }}/assets/report.pdf). 
+NotAlone was launched in connection with the White House Task Force to Protect Students from Sexual Assault.  The Task Force was established on January 22, 2014 – and since then, thousands of people have shared their stories and ideas about how best to eliminate sexual assault on our campuses and schools.
+
+Here’s our [report]({{ site.baseurl }}/assets/report.pdf).
 
 </div>
 <br>

--- a/resources/index.md
+++ b/resources/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Resources
 description: A list of helpful resources inside and outside of government.
+permalink: /resources/
 ---
 ##Find a Service Near You
 
@@ -43,7 +44,7 @@ While numbers are difficult to estimate, immigrants and international students f
 
 Find publicly supported health services including health centers, mental health providers, family planning centers and substance abuse treatment providers.
 
-*	[Community health centers](http://findahealthcenter.hrsa.gov/)  
+*	[Community health centers](http://findahealthcenter.hrsa.gov/)
 *	[Family planning providers](http://www.hhs.gov/opa/)
 *	[Mental health providers](http://findtreatment.samhsa.gov/MHTreatmentLocator/faces/quickSearch.jspx)
 
@@ -53,7 +54,7 @@ This webpage includes information on: what rape and sexual assault are; health e
 
 [Health Cares About IPV](http://www.healthcaresaboutipv.org/)
 <br>
-Health Cares about IPV is a federally funded program that provides training and technical assistance to over 22,000 health care professionals working to implement best practices for treating intimate partner violence (IPV) and dating violence survivors, including new guidelines to screen for abuse and refer patients to services. 
+Health Cares about IPV is a federally funded program that provides training and technical assistance to over 22,000 health care professionals working to implement best practices for treating intimate partner violence (IPV) and dating violence survivors, including new guidelines to screen for abuse and refer patients to services.
 
 ### Prevention Programs
 {% include resources-additional.html role="additional" type="prevention-programs" %}
@@ -68,7 +69,7 @@ Health Cares about IPV is a federally funded program that provides training and 
 
 #### Citations
 <div class="cite" id="i">
-(i)	Balsam, K. F., Beauchaine, T. P., & Rothblum, E. D. (2005). Victimization over the life span: A comparison of lesbian, gay, bisexual, and heterosexual siblings. Journal of Consulting and Clinical 
+(i)	Balsam, K. F., Beauchaine, T. P., & Rothblum, E. D. (2005). Victimization over the life span: A comparison of lesbian, gay, bisexual, and heterosexual siblings. Journal of Consulting and Clinical
 Psychology, 73(3), 477‐487.
 </div>
 
@@ -81,6 +82,6 @@ Psychology, 73(3), 477‐487.
 </div>
 
 <div class="cite" id="iv">
-(iv)	Harrell, E. (2012). Crime Against Persons with Disabilities, 2009-2011 – Statistical Tables. Bureau of 
-Justice Statistics, U.S. Department of Justice. 
+(iv)	Harrell, E. (2012). Crime Against Persons with Disabilities, 2009-2011 – Statistical Tables. Bureau of
+Justice Statistics, U.S. Department of Justice.
 </div>

--- a/schools/index.md
+++ b/schools/index.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Schools
-description: Legal guidance, promising practices, and prevention resources for schools. 
+description: Legal guidance, promising practices, and prevention resources for schools.
+permalink: /schools/
 ---
 
 ## Legal Guidance
@@ -39,17 +40,17 @@ description: Legal guidance, promising practices, and prevention resources for s
 
 <div class="section-context-links">
 * [Read the guidance](http://www2.ed.gov/about/offices/list/ocr/letters/colleague-201104.pdf)
-</div>	
+</div>
 </div>
 
 <div class="section-context-text">
 #### Dear Colleague Letter on Harassment and Bullying (2010)
 - The U.S. Department of Education’s Office for Civil Rights (OCR) released a Dear Colleague Letter in October 2010 to clarify the relationship between bullying and discriminatory harassment under civil rights laws.
 - The guidance discusses sexual harassment, gender-based harassment, racial and national origin harassment, and disability harassment and illustrates how a school should respond in each case.
-	
+
 <div class="section-context-links">
 * [Read the guidance](http://www2.ed.gov/about/offices/list/ocr/letters/colleague-201010.pdf)
-</div>	
+</div>
 </div>
 </div>
 
@@ -61,10 +62,10 @@ description: Legal guidance, promising practices, and prevention resources for s
 
 <div class="section-context-links">
 * [Read the pamphlet](https://www2.ed.gov/about/offices/list/ocr/docs/ocrshpam.pdf)
-</div>	
 </div>
-	
-<div class="section-context-text"> 
+</div>
+
+<div class="section-context-text">
 #### Revised Sexual Harassment Guidance (2001)
 - The U.S. Department of Education’s Office for Civil Rights (OCR) issued guidance in January 2001 on the sexual harassment of students by school employees, other students, or third parties. The guidance discusses in detail schools’ obligations to address the sexual harassment of students under Title IX.
 
@@ -77,13 +78,13 @@ description: Legal guidance, promising practices, and prevention resources for s
 
 ## Understanding FERPA, the Clery Act, and Title IX
 
-Colleges and universities that participate in the federal student financial aid programs are subject to Title IX and the Clery Act, and must comply their requirements that certain employees report incidents of sexual violence to school officials and notify students about the outcome when they file complaints of sexual violence. 
+Colleges and universities that participate in the federal student financial aid programs are subject to Title IX and the Clery Act, and must comply their requirements that certain employees report incidents of sexual violence to school officials and notify students about the outcome when they file complaints of sexual violence.
 
-We created a chart to help schools understand these requirements, clarify how they intersect with students' rights under FERPA, and resolve any concerns about apparent conflicts. 
+We created a chart to help schools understand these requirements, clarify how they intersect with students' rights under FERPA, and resolve any concerns about apparent conflicts.
 
 <div class="section-context-links">
 * [Review the FERPA/Clery/Title IX Chart]({{ site.baseurl }}/assets/ferpa-clerychart.pdf)
-</div>	
+</div>
 
 
 ## Maintaining Confidentiality
@@ -100,7 +101,7 @@ To help schools carry out these principles, we’ve come up with a sample report
 
 <div class="section-context-links">
 * [Read the sample reporting and confidentiality policy]({{ site.baseurl }}/assets/reporting-confidentiality-policy.pdf)
-</div>	
+</div>
 
 <div class="section-context">
 <div class="section-context-text">
@@ -109,7 +110,7 @@ The Office for Civil Rights in the Department of Health and Human Services has a
 
 <div class="section-context-links">
 * [Read the answers to the frequently asked questions](http://www.hhs.gov/ocr/privacy/hipaa/faq/ferpa_and_hipaa/)
-</div>	
+</div>
 </div>
 </div>
 
@@ -118,14 +119,14 @@ The Office for Civil Rights in the Department of Health and Human Services has a
 ### Guide to Drafting a Sexual Assault Policy
 
 Every college and university should have an easily accessible, user-friendly sexual assault policy. As the Task Force recognizes, there is no one approach that suits every school – but as we also heard, schools have had difficulty constructing comprehensive policies.  To help schools develop or reevaluate their policies:
-	
+
 We are providing schools with a checklist for a sexual misconduct policy. This list provides both a suggested process for developing a policy, as well as the key elements a school should consider in drafting one.  At the threshold, and perhaps most importantly, schools should bring all the key stakeholders to the table – including students, survivors, concerned student groups including LGBT organizations, campus security, local law enforcement, resident advisors, on-campus advocates, and local victim service providers.  Effective policies will vary in scope and detail, but an inclusive process is common to all.
-	
-We have not endeavored with this checklist to provide schools with all the answers: again, depending on its size, mission, student body, location, administrative structure and experience, a school community is best situated to decide for itself what might work best. 
+
+We have not endeavored with this checklist to provide schools with all the answers: again, depending on its size, mission, student body, location, administrative structure and experience, a school community is best situated to decide for itself what might work best.
 
 <div class="section-context-links">
 * [Read the sexual misconduct policy checklist]({{ site.baseurl }}/assets/checklist-for-campus-sexual-misconduct-policies.pdf)
-</div>	
+</div>
 
 <div class="section-context">
 <div class="section-context-text">
@@ -133,36 +134,36 @@ We have not endeavored with this checklist to provide schools with all the answe
 
 #### Key Components of Sexual Assault Crisis Intervention/Victim Service Resources
 
-Most colleges and universities seek to provide services and advocacy for victims of sexual assault. These services may be provided on campus or off campus via a memorandum of understanding with a local rape crisis center or victim advocacy program. This document discusses the existing research on sexual assault crisis intervention and victim services. It is meant to be the start of a conversation for schools as they work to ensure accessible support services for victims on their campuses. 
+Most colleges and universities seek to provide services and advocacy for victims of sexual assault. These services may be provided on campus or off campus via a memorandum of understanding with a local rape crisis center or victim advocacy program. This document discusses the existing research on sexual assault crisis intervention and victim services. It is meant to be the start of a conversation for schools as they work to ensure accessible support services for victims on their campuses.
 
 <div class="section-context-links">
 * [Read the victim services document]({{ site.baseurl }}/assets/intervention-resources.pdf)
-</div>	
+</div>
 </div>
 
 <div class="section-context-text">
-### Guidance for Developing Partnerships with Local Rape Crisis Centers 
-Colleges and universities can strengthen sexual assault prevention and response programs by developing partnerships with local rape crisis centers. These partnerships can be formalized through a Memorandum of Understanding (MOU) or other agreement between parties. MOUs are often mandated in grant applications, but schools should consider developing these partnerships regardless of whether they are applying for funding. This document provides guidance for developing these relationships along with a sample MOU. 
+### Guidance for Developing Partnerships with Local Rape Crisis Centers
+Colleges and universities can strengthen sexual assault prevention and response programs by developing partnerships with local rape crisis centers. These partnerships can be formalized through a Memorandum of Understanding (MOU) or other agreement between parties. MOUs are often mandated in grant applications, but schools should consider developing these partnerships regardless of whether they are applying for funding. This document provides guidance for developing these relationships along with a sample MOU.
 
 <div class="section-context-links">
 * [Read guidance and the sample rape crisis center memorandum of understanding]({{ site.baseurl }}/assets/mou-rape-crisis-centers.pdf)
-</div>	
 </div>
-</div> 
+</div>
+</div>
 
 <div class="section-context">
 <div class="section-context-text">
 ### Accessing Federal Resources for Your Campus and Community
 
 #### The Office on Violence Against Women
-Campuses and communities interested in building or strengthening sexual assault programs should consider applying for a grant through the Department of Justice Office on Violence Against Women. 
+Campuses and communities interested in building or strengthening sexual assault programs should consider applying for a grant through the Department of Justice Office on Violence Against Women.
 
 <div class="section-context-links">
 * [Click for additional information](http://www.ovw.usdoj.gov/ovwgrantprograms.htm)
 </div>
 
 #### The Centers for Disease Control and Prevention
-The Centers for Disease Control and Prevention’s Rape Prevention and Education program (RPE) strengthens sexual violence prevention efforts at the local, state, and national level.  RPE grantees are located in all 50 states, the District of Columbia, Puerto Rico, and six U.S. territories.  Eligible grantees are state and territorial health departments.      
+The Centers for Disease Control and Prevention’s Rape Prevention and Education program (RPE) strengthens sexual violence prevention efforts at the local, state, and national level.  RPE grantees are located in all 50 states, the District of Columbia, Puerto Rico, and six U.S. territories.  Eligible grantees are state and territorial health departments.
 
 <div class="section-context-links">
 * [Click for additional information](http://www.cdc.gov/violencePrevention/RPE/index.html)
@@ -177,7 +178,7 @@ Many schools are working to address sexual assault on their campuses, but lack a
 
 <div class="section-context-links">
 * [Review the guide to conducting climate surveys]({{ site.baseurl }}/assets/ovw-climate-survey.pdf)
-</div>	
+</div>
 </div>
 </div>
 
@@ -192,21 +193,21 @@ Bystander intervention is a sexual assault prevention strategy that encourages w
 
 <div class="section-context-links">
 * [Read the bystander intervention document]({{ site.baseurl }}/assets/bystander-summary.pdf)
-</div>	
+</div>
 <div class="section-context-links">
 * [Read additional information about bystander intervention compiled by the National Sexual Violence Resource Center](http://www.nsvrc.org/projects/engaging-bystanders-sexual-violence-prevention/bystander-intervention-resources)
-</div>	
+</div>
 </div>
 
 <div class="section-context-text">
 #### Preventing Sexual Violence on College Campuses: Lessons from Research and Practice
 
-This document created by the Centers for Disease Control and Prevention describes the best practices in developing, selecting, and implementing prevention strategies with the highest chance of successfully changing sexual violence in communities. While we have a lot to learn about how best to stop campus sexual violence before it starts, there are important steps that college campuses can take now to better address sexual violence. 
+This document created by the Centers for Disease Control and Prevention describes the best practices in developing, selecting, and implementing prevention strategies with the highest chance of successfully changing sexual violence in communities. While we have a lot to learn about how best to stop campus sexual violence before it starts, there are important steps that college campuses can take now to better address sexual violence.
 
 
 <div class="section-context-links">
 * [Read the CDC report on best practices for sexual violence prevention]({{ site.baseurl }}/assets/evidence-based-strategies-for-the-prevention-of-sv-perpetration.pdf)
-</div>	
+</div>
 </div>
 </div>
 
@@ -219,7 +220,7 @@ Preventing sexual assault in a college setting requires a thoughtful, well-plann
 
 <div class="section-context-links">
 * [Read the strategic planning for campuses document]({{ site.baseurl }}/assets/prevention-overview.pdf)
-</div>	
+</div>
 </div>
 
 <div class="section-context-text">
@@ -228,18 +229,18 @@ Prevention efforts should ultimately decrease the number of individuals who perp
 
 <div class="section-context-links">
 * [Read Sexual Violence Prevention Strategies: An Overview](http://www.cdc.gov/violenceprevention/sexualviolence/prevention.html)
-</div>	
+</div>
 </div>
 </div>
 
 <div class="section-context">
 <div class="section-context-text">
-#### American College Health Association Sexual Violence Toolkit 
-The American College Health Association developed the Shifting the Paradigm: Primary Prevention of Sexual Violence toolkit to provide facts, ideas, strategies, conversation starters, and resources to everyone on campus who cares about the prevention of sexual violence. While there is a rich volume of tools, knowledge, and resources for intervention after sexual violence, the emphasis of this toolkit is to encourage prevention activities that take place before sexual violence has occurred and which create social change and shift the norms regarding sexual violence. 
+#### American College Health Association Sexual Violence Toolkit
+The American College Health Association developed the Shifting the Paradigm: Primary Prevention of Sexual Violence toolkit to provide facts, ideas, strategies, conversation starters, and resources to everyone on campus who cares about the prevention of sexual violence. While there is a rich volume of tools, knowledge, and resources for intervention after sexual violence, the emphasis of this toolkit is to encourage prevention activities that take place before sexual violence has occurred and which create social change and shift the norms regarding sexual violence.
 
 <div class="section-context-links">
 * [Review the American College Health Association Sexual Violence Toolkit](http://www.acha.org/sexualviolence/docs/ACHA_PSV_toolkit.pdf)
-</div>	
+</div>
 </div>
 
 <div class="section-context">
@@ -249,7 +250,7 @@ The goal of the RPE program is to strengthen sexual violence prevention efforts.
 
 <div class="section-context-links">
 * [Review the Rape Prevention and Education (RPE) Program](http://www.cdc.gov/violenceprevention/rpe/index.html)
-</div>	
+</div>
 </div>
 </div>
 
@@ -260,8 +261,8 @@ Program evaluation is a type of research. In some cases, external researchers or
 
 <div class="section-context-links">
 * [Review the collection of program evaluation strategies](http://www.nsvrc.org/xchange-forum/program-evaluation)
-</div>	
-</div>	
+</div>
+</div>
 
 <div class="section-context-text">
 #### Peer Educators: The Frontline in Campus Violence Prevention
@@ -269,13 +270,13 @@ Information about the roles and responsibilities of peer education in violence p
 
 <div class="section-context-links">
 * [Review the Peer Educators: The Frontline in Campus Violence Prevention document](http://www.vawnet.org/sexual-violence/summary.php?doc_id=3626&find_type=web_desc_TT)
-</div>	
+</div>
 </div>
 </div>
 
 <div class="section-context">
 <div class="section-context-text">
-#### Assessing Campus Readiness Manual 
+#### Assessing Campus Readiness Manual
 A campus-wide approach to sexual violence and explore topics such as evaluating efforts, partnering with campus leaders, assessing campus readiness, and educating campus leaders created by Pennsylvania Coalition Against Rape.
 
 <div class="section-context-links">

--- a/search/index.md
+++ b/search/index.md
@@ -2,6 +2,7 @@
 layout: search
 title: Search
 description: Find resources, reports, and documents related to sexual assault on college campuses.
+permalink: /search/
 ---
 
 Find resources, reports, and documents related to sexual assault on college campuses.

--- a/students/index.md
+++ b/students/index.md
@@ -2,43 +2,44 @@
 layout: default
 title: Students
 description: Information about legal rights, how to file a complaint, definitions of key terms, and confidentiality for students.
+permalink: /students/
 
 ---
 
-## What do I do if I have been sexually assaulted? 
+## What do I do if I have been sexually assaulted?
 
-### Immediately after an assault 
+### Immediately after an assault
 
 #### Ask for help, make a call:
 * 911
 *	Campus police
 *	Friends or family
-* Crisis hotline 800-656-HOPE (4673) 
+* Crisis hotline 800-656-HOPE (4673)
 
 #### Go to urgent care (e.g., a hospital):
-*	Receive help for physical injuries. 
-* Screen for STDs/pregnancy. 
+*	Receive help for physical injuries.
+* Screen for STDs/pregnancy.
 * If possible, do not shower or cleaning up. Do not change clothes. Hospital staff can collect evidence using a rape kit.
-* If you want to file a police report, you can call the police from the emergency room. 
+* If you want to file a police report, you can call the police from the emergency room.
 * Ask about the [nearest rape crisis center]({{ site.baseurl }}/resources/#find-a-service-near-you).
 
-### Days following an assault 
+### Days following an assault
 Take care of your physical and emotional well-being. Try to eat well, get enough sleep, and exercise. Remember that it was not your fault and you are not alone.
 
-#### Learn about common reactions to trauma. 
+#### Learn about common reactions to trauma.
 Everyone is different, but it is good to understand [what you might expect](http://www.ptsd.va.gov/public/problems/common-reactions-after-trauma.asp) and know that others have experienced similar reactions.
 
-#### Let others help. 
+#### Let others help.
 *	**Friends and family** can offer support by listening to you, keeping you company, walking to class with you, or going with you to appointments.
-*	**Campus health centers** can provide health services and help you find additional health resources including counseling. 
+*	**Campus health centers** can provide health services and help you find additional health resources including counseling.
     * If you are concerned about confidentiality ask the person you want to talk to first about his/her obligation to disclose information you share (e.g., filing a report). Click [here]({{ site.baseurl }}/students#will-what-i-share-remain-confidential) for more information.
-* **Local rape crisis center staff** are experienced with how to help you. They can help you make choices about reporting an assault, joining a support group or finding a counselor. 
+* **Local rape crisis center staff** are experienced with how to help you. They can help you make choices about reporting an assault, joining a support group or finding a counselor.
 * Click [here]({{ site.baseurl }}/assets/know-your-rights.pdf) to learn more about what accommodations should be offered to you.
 
 ### Months after an assault
 
 * Recovery is an **ongoing gradual process**. Understand [common reactions after trauma](http://www.ptsd.va.gov/public/problems/common-reactions-after-trauma.asp). Some symptoms may appear months after an assault.
-* **Reach out** to your personal support network of friends and family. Find a support group. 
+* **Reach out** to your personal support network of friends and family. Find a support group.
 * **Talk to a counselor or psychologist.** They are experienced in helping individuals who have been sexually assaulted. They are familiar with the physiological and psychological effects that traumatic events cause. They can help you work through your emotions and teach you coping skills. Learn more [here](http://www.womenshealth.gov/mental-health/help/index.html).
 * If your school does not offer mental health services, find a provider [here](http://samhsa.gov/tools/).
 
@@ -54,7 +55,7 @@ Students, staff, faculty, and other employees; women, girls, men, and boys; stra
 Sex-based discrimination in public schools also implicates legal rights under Title IV of the Civil Rights Act, which is enforced by the U.S. Department of Justice.
 
 <div class="section-context-links">
-* [Find out more about your rights under Title IX]({{ site.baseurl }}/assets/know-your-rights.pdf) 
+* [Find out more about your rights under Title IX]({{ site.baseurl }}/assets/know-your-rights.pdf)
 * [Conoce tus derechos: El Título IX requiere que tu escuela tome medidas contra la violencia sexual]({{ site.baseurl }}/assets/know-your-rights-espanol.pdf)
 * [Click to review school-by-school enforcement actions]({{ site.baseurl }}/data#school-by-school-enforcement-map)
 </div>
@@ -64,21 +65,21 @@ Sex-based discrimination in public schools also implicates legal rights under Ti
 #### What are a school’s responsibilities under Title IX to address sexual violence?
 - A school has a responsibility to respond promptly and effectively to reports of sexual violence.
 
-- If a school knows (or reasonably should know) about possible sexual violence, it must quickly investigate to determine what occurred and then take appropriate steps to resolve the situation. 
+- If a school knows (or reasonably should know) about possible sexual violence, it must quickly investigate to determine what occurred and then take appropriate steps to resolve the situation.
 - A criminal investigation into allegations of sexual violence does not relieve a school of its duty under Title IX to resolve reports promptly and effectively.
 
 - A school must ensure that the person who experienced the sexual violence is safe, even while an investigation is ongoing.
 </div>
 </div>
 
-## How Do I File a Complaint About My School? And Then What Happens? 
+## How Do I File a Complaint About My School? And Then What Happens?
 <div class="section-context">
 ### Can I File a Complaint?
 
 <div class="section-context-text">
 If you believe you are a victim of sex-based discrimination in an educational program receiving funding from the federal government, you can file a Title IX complaint with both the U.S. Department of Education and the U.S. Department of Justice (DOJ). Programs or activities receiving federal financial assistance include virtually all public and private colleges and universities, and all public elementary and secondary schools.
 
-If you file a complaint of sex-based discrimination with the DOJ, it can also be reviewed under Title IV of the Civil Rights Act of 1964 (Title IV), which provides similar protections to Title IX at all public schools. 
+If you file a complaint of sex-based discrimination with the DOJ, it can also be reviewed under Title IV of the Civil Rights Act of 1964 (Title IV), which provides similar protections to Title IX at all public schools.
 
 
 </div>
@@ -88,7 +89,7 @@ If you file a complaint of sex-based discrimination with the DOJ, it can also be
 
 No, though the process is quite similar. The U.S. Department of Education's Office for Civil Rights (OCR) has the authority to investigate all allegations of Title IX violations at educational institutions that receive federal funding. DOJ can investigate allegations of sex-based discrimination at educational institutions that receive DOJ funds (e.g., [a grant from the Office on Violence Against Women](http://www.ovw.usdoj.gov/grant2013.htm)) under Title IX and at all public schools under Title IV. If you file with both DOJ and OCR, **usually, one agency will conduct the investigation of the school**. Occasionally, both agencies will conduct a joint investigation.
 
-Both OCR and DOJ can and do conduct proactive compliance reviews under Title IX of schools the Departments fund, even in the absence of a complaint. 
+Both OCR and DOJ can and do conduct proactive compliance reviews under Title IX of schools the Departments fund, even in the absence of a complaint.
 
 </div>
 </div>
@@ -146,17 +147,17 @@ After receiving a complaint, DOJ conducts an initial review. DOJ will inform you
 <div class="section-context-text">
 
 Sexual assault survivors respond in different ways. Some are able to be public about what has happened to them. Some are ready to press forward with a formal complaint. Others aren’t so sure. And they need someone they can talk to confidentially -- to try to regain a sense of control, to start healing, and to sort through their options at their own pace.
- 
+
 If you feel this way, know that not all of a school’s employees can maintain your confidentiality. Your school should make clear who you can turn to – like professional or pastoral counselors, or maybe a women’s center or health center – to talk confidentially. Your school should also make clear who **can’t** maintain confidentiality; if you talk to these people – they’re sometimes called “responsible employees” – you have the right to expect your school to investigate what happened and to take prompt action to address the situation. If you’re not sure if someone can maintain your confidentiality – ask before you talk to them.
- 
+
 To help make you more aware of your options, we are providing a sample policy on reporting and confidentiality for schools to consider. As with all policies, we urge schools to involve students in coming up with the best solutions.  But all policies should make clear, up front, who on campus must share what information with whom – and how a school should weigh a survivor’s request for confidentiality against its own obligation to provide a safe environment for all students.
- 
-In general, rape crisis center advocates can speak with you confidentially. But because state law is always changing, be sure to check the accuracy of this information. 
+
+In general, rape crisis center advocates can speak with you confidentially. But because state law is always changing, be sure to check the accuracy of this information.
 </div>
 
 <div class="section-context-text">
 #### State Confidentiality Laws
-While this list is a helpful tool, it is not a replacement for asking the person whether or not they are a confidential resource. Since state law is constantly changing on this issue, **be sure to verify the information** provided in this guide. 
+While this list is a helpful tool, it is not a replacement for asking the person whether or not they are a confidential resource. Since state law is constantly changing on this issue, **be sure to verify the information** provided in this guide.
 
 <div class="section-context-links">
 * [Click to download a guide to state laws governing advocate confidentiality](http://www.americanbar.org/content/dam/aba/uncategorized/cdsv-related/Advocate_Confidentiality_Chart_2_2014.authcheckdam.pdf)
@@ -177,12 +178,12 @@ The Office for Civil Rights in the U.S. Department of Health and Human Services 
 
 ## How Can I Help a Friend?
 
-* You can help someone who has been assaulted by listening and offering comfort. 
-* Go with her or him to the health center, hospital, administrator’s office or counseling. 
+* You can help someone who has been assaulted by listening and offering comfort.
+* Go with her or him to the health center, hospital, administrator’s office or counseling.
 * Reinforce the message that your friend is not at fault and that it is natural to feel angry and ashamed.
 * Encourage your friend to take care of him or herself by eating, sleeping and exercising as best possible.
-* Keep an eye out for common problems associated with traumatic events. 
-* Become an advocate. [Join or start an organization]({{ site.baseurl }}/resources). 
+* Keep an eye out for common problems associated with traumatic events.
+* Become an advocate. [Join or start an organization]({{ site.baseurl }}/resources).
 
 
 


### PR DESCRIPTION
This adds a `rel="canonical"` link to the top of every page, with an absolute URL to `https://www.notalone.gov`, so that search engines aren't confused about any instance of this code on other domains (like `18f.github.io/notalone`). Essentially, it prevents penalization for duplicate content and transfers all pagerank to the canonical domain.

To do this, I also added a `permalink` field to every page -- otherwise, the `page.url` field always adds `index.html` to the end of every canonical URL. I added the base canonical URL to `_config.yml` as a `canonical` field.

For more information on `rel="canonical"`, Google's description: https://support.google.com/webmasters/answer/139066?hl=en

It looks like my text editor also deleted a lot of trailing whitespace (I have it configured to do that automatically on save). You can view the diff without that by adding `?w=1` to the end of this pull request's URL.
