### PR TITLE
Updates DAP snippet, tightens GA settings

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,21 +23,21 @@
       <link href="{{ site.baseurl }}/static/css/ie8.css" rel="stylesheet">
     <![endif]-->
     <!--[if IE]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 
     <script src="{{ site.baseurl }}/static/js/min/jquery.min.js"></script>
   <!--  <script src="{{ site.baseurl }}/static/js/min/iecors.min.js"></script> -->
   <!--[if lte IE 9]>
-  <script type='text/javascript' src='//cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.0/jquery.xdomainrequest.min.js'></script>
+  <script type='text/javascript' src='https://cdnjs.cloudflare.com/ajax/libs/jquery-ajaxtransport-xdomainrequest/1.0.0/jquery.xdomainrequest.min.js'></script>
   <![endif]-->
 
   </head>
   <body>
     <div class="usa">An official website of the United States Government <img class="flag" alt="US flag signifying that this is a United States Federal Government website" src="{{ site.baseurl }}/static/img/us_flag_small.png" class="USA Flag" /></div>
     <header role="banner" class="site-header">
-      <a class="btn btn-escape" href="http://google.com" id="escape">Escape</a>
+      <a class="btn btn-escape" href="https://www.google.com" id="escape">Escape</a>
       <div class="container">
         <div class="site-header-content">
           <hgroup>
@@ -143,13 +143,17 @@
       </footer>
   </div>
   <script>
-    (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-    function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-    e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-    e.src='//www.google-analytics.com/analytics.js';
-    r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-    ga('create','UA-48605964-4');ga('send','pageview');
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    
+    ga('create', 'UA-48605964-4', 'auto');
+    ga('set', 'anonymizeIp', true);
+    ga('set', 'forceSSL', true);
+    ga('send', 'pageview');
   </script>
+
   <script src="{{ site.baseurl }}/static/js/min/init.min.js?c={{ site.cachebuster }}"></script>
   {% for include in site.data.js-includes %}
   {% for node in include.pages %}
@@ -160,7 +164,7 @@
   {% endfor %}
   
   <!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
-  <script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
   
   </body>
 </html>


### PR DESCRIPTION
This changes the DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.

This also tightens up the GA settings to follow [18F's standard analytics settings](https://github.com/18F/analytics-standards#javascript-code-snippet).
